### PR TITLE
Adds logic to get commit count from open prod PR

### DIFF
--- a/.github/workflows/manage-prod-deploy-pr.yml
+++ b/.github/workflows/manage-prod-deploy-pr.yml
@@ -18,7 +18,10 @@ jobs:
                 pullRequests(baseRefName: "master", headRefName: "develop", states: [OPEN], first: 1) {
                   nodes {
                     number,
-                    body
+                    body,
+                    commits(first: 5) {
+                      totalCount
+                    }
                   }
                 }
               }
@@ -34,6 +37,7 @@ jobs:
           json: ${{ steps.get_production_pr_number.outputs.data }}
           number: "repository.pullRequests.nodes[0].number"
           body: "repository.pullRequests.nodes[0].body"
+          commit_count: "repository.pullRequests.nodes[0].commits.totalCount"
       - name: Get first line of commit message
         id: get_commit_message
         uses: actions/github-script@v3
@@ -64,36 +68,9 @@ jobs:
         env:
           COMMIT_MSG: ${{ steps.get_commit_message.outputs.result }}
           AUTHOR_USERNAME: ${{ github.event.commits[0].author.username }}
-      # NEW__________________________________________________
-      - name: If Production PR exists, count commits
-        if: ${{ steps.pull_requests_json.outputs.number }}
-        id: get_prod_pr_commits
-        uses: octokit/graphql-action@v2.x
-        with:
-          query: |
-            query release($owner:String!,$repo:String!) {
-              repository(owner:$owner,name:$repo) {
-                pullRequests(baseRefName: "master", headRefName: "develop", states: [OPEN], first: 1) {
-                  nodes {
-                    commits(first: 5) {
-                      totalCount
-                    }
-                  }
-                }
-              }
-            }
-          owner: ${{ github.event.repository.owner.name }}
-          repo: ${{ github.event.repository.name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Parse response to JSON
-        id: get_prod_pr_commits_json
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.check_prod_pr_full.outputs.data }}
-          count: "repository.pullRequests.nodes[0].commits.totalCount"
       - name: Update Production PR if one exists and isn't full
-        if: ${{ steps.pull_requests_json.outputs.number && steps.get_prod_pr_commits_json.outputs.count < 5 }}
+        # NEW____________________________________________________________
+        if: ${{ steps.pull_requests_json.outputs.number && steps.pull_requests_json.outputs.commit_count < 5 }}
         # END NEW____________________________________________________________
         uses: actions/github-script@v3
         with:

--- a/.github/workflows/manage-prod-deploy-pr.yml
+++ b/.github/workflows/manage-prod-deploy-pr.yml
@@ -1,0 +1,111 @@
+name: Create or update Production Deploy PR
+on:
+  push:
+    branches:
+      - "develop"
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get open pull requests against master
+        id: get_production_pr_number
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query release($owner:String!,$repo:String!) {
+              repository(owner:$owner,name:$repo) {
+                pullRequests(baseRefName: "master", headRefName: "develop", states: [OPEN], first: 1) {
+                  nodes {
+                    number,
+                    body
+                  }
+                }
+              }
+            }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse response to JSON
+        id: pull_requests_json
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.get_production_pr_number.outputs.data }}
+          number: "repository.pullRequests.nodes[0].number"
+          body: "repository.pullRequests.nodes[0].body"
+      - name: Get first line of commit message
+        id: get_commit_message
+        uses: actions/github-script@v3
+        with:
+          script: |
+            if (!process.env.COMMIT_MSG) {
+              return "";
+            }
+
+            return process.env.COMMIT_MSG.split(/\r?\n/)[0];
+          result-encoding: string
+        env:
+          COMMIT_MSG: ${{ github.event.commits[0].message }}
+      - name: Create Production PR if one doesn't exist
+        if: ${{ !steps.pull_requests_json.outputs.number }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Production Deploy",
+              body: `- [ ] ${process.env.COMMIT_MSG} @${process.env.AUTHOR_USERNAME}`,
+              head: "develop",
+              base: "master"
+            })
+        env:
+          COMMIT_MSG: ${{ steps.get_commit_message.outputs.result }}
+          AUTHOR_USERNAME: ${{ github.event.commits[0].author.username }}
+      # NEW__________________________________________________
+      - name: If Production PR exists, count commits
+        if: ${{ steps.pull_requests_json.outputs.number }}
+        id: get_prod_pr_commits
+        uses: octokit/graphql-action@v2.x
+        with:
+          query: |
+            query release($owner:String!,$repo:String!) {
+              repository(owner:$owner,name:$repo) {
+                pullRequests(baseRefName: "master", headRefName: "develop", states: [OPEN], first: 1) {
+                  nodes {
+                    commits(first: 5) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse response to JSON
+        id: get_prod_pr_commits_json
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.check_prod_pr_full.outputs.data }}
+          count: "repository.pullRequests.nodes[0].commits.totalCount"
+      - name: Update Production PR if one exists and isn't full
+        if: ${{ steps.pull_requests_json.outputs.number && steps.get_prod_pr_commits_json.outputs.count < 5 }}
+        # END NEW____________________________________________________________
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${process.env.PR_BODY}\n- [ ] ${process.env.COMMIT_MSG} @${process.env.AUTHOR_USERNAME}`,
+              pull_number: ${{ steps.pull_requests_json.outputs.number }}
+            })
+        env:
+          PR_BODY: ${{ steps.pull_requests_json.outputs.body }}
+          COMMIT_MSG: ${{ steps.get_commit_message.outputs.result }}
+          AUTHOR_USERNAME: ${{ github.event.commits[0].author.username }}


### PR DESCRIPTION
(Implements existing prod PR action from Gousto/gousto-webclient)

_Updated code wrapped in #NEW -> END NEW_

- If there's an existing prod PR, count the commits
- Only update prod PR if it isn't full

## Todo
- (Test this works once merged)
- Add env variable for max commit count

## Notes
- This logic (however simple) is getting a bit hectic for mashing actions up and working in .yml exclusively, I'd be keen to whip something up in TS